### PR TITLE
add "use strict" for node.js v4 support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+"use strict";
+
 const getStdin = require("get-stdin");
 const coreRules = require("./rules/core");
 const reactRules = require("./rules/react");


### PR DESCRIPTION
Without the `'use strict';` Node.js v4.x will choke on let/const