### PR TITLE
Add one-var-declaration-per-line to disabled rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = {
     "object-curly-newline": "off",
     "object-curly-spacing": "off",
     "object-property-newline": "off",
+    "one-var-declaration-per-line": "off",
     "operator-linebreak": "off",
     "padded-blocks": "off",
     "quote-props": "off",


### PR DESCRIPTION
one-var-declaration-per-line causes this error when use with eslint-plugin-prettier:

```
  #:#  error  Follow `prettier` formatting (expected ' ' but found '\n')  prettier/prettier
```
with this code:
```
var a = 'a', 
  b = 'b';
```