### PR TITLE
Grammar change on description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-config-prettier [![Build Status][travis-badge]][travis]
 
-Turns all rules that are unnecessary or might conflict with [prettier] off.
+Turns off all rules that are unnecessary or might conflict with [prettier].
 
 This let’s you use you favorite shareable config without letting its stylistic
 choices get in the way when using prettier.


### PR DESCRIPTION
I propose the grammar of the description is changed to be less ambiguous. (I initially read it as: it could be potentially conflict if Prettier is turned off.)

If this PR is merged, the change would need to be reflected in the repo description, too.