### PR TITLE
Turn "template-tag-spacing" off

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = {
     "space-in-parens": "off",
     "space-unary-ops": "off",
     "template-curly-spacing": "off",
+    "template-tag-spacing": "off",
     "unicode-bom": "off",
     "wrap-iife": "off",
     "wrap-regex": "off",


### PR DESCRIPTION
Hi Simon,

The [template-tag-spacing](http://eslint.org/docs/rules/template-tag-spacing) rule is already handled by prettier as you can see:  https://prettier.github.io/prettier/#%7B%22content%22%3A%22func%60Hello%20world%60%3B%5Cnfunc%20%60Hello%20world%60%3B%22%2C%22options%22%3A%7B%22printWidth%22%3A80%2C%22tabWidth%22%3A2%2C%22singleQuote%22%3Afalse%2C%22trailingComma%22%3Afalse%2C%22bracketSpacing%22%3Atrue%2C%22jsxBracketSameLine%22%3Afalse%2C%22doc%22%3Afalse%7D%7D